### PR TITLE
gentoo-git-squash: pass -q to gemato

### DIFF
--- a/gentoo-git-squash
+++ b/gentoo-git-squash
@@ -43,7 +43,7 @@ git -C "${gitdir}" gc ${quiet}
 if [[ ${gpg_verify} == 1 ]] ; then
 	type -P gemato &>/dev/null || exit 1
 
-	verify_result=$(gemato gpg-wrap -K "${key_path}" -- git -C "${gitdir}" log -n1 --pretty=format:%G? 2>/dev/null) || exit 1
+	verify_result=$(gemato gpg-wrap -q -K "${key_path}" -- git -C "${gitdir}" log -n1 --pretty=format:%G? 2>/dev/null) || exit 1
 
 	if [[ ${verify_result} != "G" ]] ; then
 		echo "Could not verify!"


### PR DESCRIPTION
This ensures that the "G" check always succeeds and isn't confused by noise. Given that verification has been working for me for ages, I assume it might have only been a problem with set -x or something, but let's fix it anyway.